### PR TITLE
Remove extraneous null value checks

### DIFF
--- a/app/src/main/java/org/pocketworkstation/pckeyboard/LatinKeyboardBaseView.kt
+++ b/app/src/main/java/org/pocketworkstation/pckeyboard/LatinKeyboardBaseView.kt
@@ -659,19 +659,19 @@ open class LatinKeyboardBaseView @JvmOverloads constructor(
 
     fun setCtrlIndicator(active: Boolean) {
         if (mKeyboard != null) {
-            invalidateKey(mKeyboard!!.setCtrlIndicator(active)!!)
+            invalidateKey(mKeyboard!!.setCtrlIndicator(active))
         }
     }
 
     fun setAltIndicator(active: Boolean) {
         if (mKeyboard != null) {
-            invalidateKey(mKeyboard!!.setAltIndicator(active)!!)
+            invalidateKey(mKeyboard!!.setAltIndicator(active))
         }
     }
 
     fun setMetaIndicator(active: Boolean) {
         if (mKeyboard != null) {
-            invalidateKey(mKeyboard!!.setMetaIndicator(active)!!)
+            invalidateKey(mKeyboard!!.setMetaIndicator(active))
         }
     }
 


### PR DESCRIPTION
This fixes a crash caused by using the Fn key twice in the condensed 5 row keyboard layout.

(Fixes issue https://github.com/SeventhM/hackerskeyboard/issues/7#issue-2414982551)